### PR TITLE
Add basic tests for HasManyCount field

### DIFF
--- a/tests/FieldStub.php
+++ b/tests/FieldStub.php
@@ -1,0 +1,36 @@
+<?php
+namespace Laravel\Nova\Fields;
+
+class Field
+{
+    public $component;
+    public $attribute;
+    public $value;
+    public $id;
+    public $meta = [];
+    public $showOnIndex = false;
+    public $showOnDetail = true;
+    public $showOnCreation = true;
+    public $showOnUpdate = true;
+
+    public function __construct(?string $name = null, ?string $attribute = null)
+    {
+        $this->attribute = $attribute ?? $name;
+    }
+
+    public function meta(): array
+    {
+        return $this->meta;
+    }
+
+    public function withMeta(array $meta): static
+    {
+        $this->meta = array_merge($this->meta, $meta);
+        return $this;
+    }
+
+    public function resolveForDisplay(mixed $resource, ?string $attribute = null): void
+    {
+        // To be overridden in child classes.
+    }
+}

--- a/tests/HasManyCountTest.php
+++ b/tests/HasManyCountTest.php
@@ -1,0 +1,55 @@
+<?php
+require __DIR__ . '/FieldStub.php';
+require __DIR__ . '/../src/HasManyCount.php';
+
+use Sashalenz\HasManyCount\HasManyCount;
+
+// Create a dummy related model with a count method
+$related = new class {
+    public function count(): int
+    {
+        return 2;
+    }
+};
+
+// Create a resource that has a relationship method
+$resource = new class($related) {
+    public $id = 7;
+
+    public function __construct(private $relation)
+    {
+    }
+
+    public function comments()
+    {
+        return $this->relation;
+    }
+};
+
+$field = new HasManyCount('Comments', 'comments');
+
+// Assert default visibility flags
+assert($field->component === 'has-many-count');
+assert($field->showOnIndex === true);
+assert($field->showOnDetail === false);
+assert($field->showOnCreation === false);
+assert($field->showOnUpdate === false);
+
+// Resolve using attribute from constructor
+$field->resolveForDisplay($resource);
+assert($field->value === 2);
+assert($field->id === 7);
+
+// Resolve using explicit attribute parameter
+$field2 = new HasManyCount('Dummy', 'dummy');
+$field2->resolveForDisplay($resource, 'comments');
+assert($field2->value === 2);
+assert($field2->id === 7);
+
+// Test meta information merging
+$field->withMeta(['foo' => 'bar']);
+$meta = $field->meta();
+assert($meta['id'] === 7);
+assert($meta['foo'] === 'bar');
+
+echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- add a lightweight Nova Field stub for testing
- cover default visibility, relation resolution, and meta merging for `HasManyCount`

## Testing
- `php tests/HasManyCountTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeed01c82c8325a57211a6c6f8b0be